### PR TITLE
Handle multivalued fields in roles filters

### DIFF
--- a/classes/wp_cassify_rule_solver.php
+++ b/classes/wp_cassify_rule_solver.php
@@ -96,7 +96,12 @@ class wp_cassify_rule_solver {
 
 		if ( ( is_array( $matches_cas_variable_groups[1] ) ) && ( count( $matches_cas_variable_groups[1] ) == 1 ) ) {
 			// Replace with real value if it's a CAS variable and not a constant.
-			$wp_cassify_rule_operand = $this->cas_user_datas[ $matches_cas_variable_groups[1][0] ];
+			if ( is_array( $this->cas_user_datas[ $matches_cas_variable_groups[1][0] ] ) ) {
+				$wp_cassify_rule_operand = maybe_serialize( $this->cas_user_datas[ $matches_cas_variable_groups[1][0] ] );
+			}
+			else {
+				$cas_user_data_formatted = $this->cas_user_datas[ $matches_cas_variable_groups[1][0] ];
+			}
 		}
 	}	
 	


### PR DESCRIPTION
This allow to handle multivalued fields in roles assignation filters.

For example this filter will work correctly : 

role1|(CAS{memberOf} -CONTAINS "cn=ROLE1")

Form this response XML : 

```
<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
    <cas:authenticationSuccess>
        <cas:user>tuser</cas:user>
        <cas:attributes>
            <cas:isFromNewLogin>true</cas:isFromNewLogin>
            <cas:mail>test@test.fr</cas:mail>
            <cas:authenticationDate>2021-04-27T10:33:52.006071Z</cas:authenticationDate>
            <cas:givenName>Test</cas:givenName>
            <cas:successfulAuthenticationHandlers>LdapAuthenticationHandler</cas:successfulAuthenticationHandlers>
            <cas:cn>Test User</cas:cn>
            <cas:credentialType>UsernamePasswordCredential</cas:credentialType>
            <cas:uid>tuser</cas:uid>
            <cas:authenticationMethod>LdapAuthenticationHandler</cas:authenticationMethod>
            <cas:longTermAuthenticationRequestTokenUsed>false</cas:longTermAuthenticationRequestTokenUsed>
            <cas:memberOf>cn=USER,ou=roles,dc=lepuyenvelay,dc=fr</cas:memberOf>
            <cas:memberOf>cn=TEST1,ou=roles,dc=lepuyenvelay,dc=fr</cas:memberOf>
            <cas:sn>User</cas:sn>
            </cas:attributes>
    </cas:authenticationSuccess>
</cas:serviceResponse>
```
					